### PR TITLE
Added missing line com.example.coopt3 that caused the app to crash

### DIFF
--- a/app/src/main/java/com/example/coopt3/MainActivity.kt
+++ b/app/src/main/java/com/example/coopt3/MainActivity.kt
@@ -1,3 +1,5 @@
+package com.example.coopt3
+
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent


### PR DESCRIPTION
Missing line causes the android manifest.xml file to not be able to register where MainActivity is which caused the instant crash when trying to run the app on android studio